### PR TITLE
fix: change kotlin dependency to provided to avoid conflicts in proje…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
+            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
…cts where koson is used

Otherwise, client projects are forced to exclude kotlin-stdlib-jdk8 to avoid multiple koson-stblib versions.